### PR TITLE
⬆ Bump python from 3.10 to 3.13 in /backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.13
 
 ENV PYTHONUNBUFFERED=1
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.13
 
+
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app/


### PR DESCRIPTION
Bumps python from 3.10 to 3.13.

---
updated-dependencies:
- dependency-name: python dependency-version: '3.13' dependency-type: direct:production update-type: version-update:semver-minor ...